### PR TITLE
Add Code Coverage Support for the CognitiveMetrics Command

### DIFF
--- a/src/Business/CodeCoverage/CodeCoverageFactory.php
+++ b/src/Business/CodeCoverage/CodeCoverageFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\CognitiveCodeAnalysis\Business\CodeCoverage;
+
+use Phauthentic\CognitiveCodeAnalysis\CognitiveAnalysisException;
+
+class CodeCoverageFactory
+{
+    public static function createFromName(string $name, string $filePath): CoverageReportReaderInterface
+    {
+        return match (strtolower($name)) {
+            'clover' => new CloverReader($filePath),
+            'cobertura' => new CoberturaReader($filePath),
+            default => throw new CognitiveAnalysisException("Unknown code coverage implementation: {$name}"),
+        };
+    }
+}

--- a/src/Business/Cognitive/CognitiveMetrics.php
+++ b/src/Business/Cognitive/CognitiveMetrics.php
@@ -64,6 +64,7 @@ class CognitiveMetrics implements JsonSerializable
 
     private ?HalsteadMetrics $halstead = null;
     private ?CyclomaticMetrics $cyclomatic = null;
+    private ?float $coverage = null;
 
     /**
      * @param array<string, mixed> $metrics
@@ -340,6 +341,16 @@ class CognitiveMetrics implements JsonSerializable
         return $this->score;
     }
 
+    public function setCoverage(?float $coverage): void
+    {
+        $this->coverage = $coverage;
+    }
+
+    public function getCoverage(): ?float
+    {
+        return $this->coverage;
+    }
+
     public function getLineCountWeightDelta(): ?Delta
     {
         return $this->lineCountWeightDelta;
@@ -435,6 +446,7 @@ class CognitiveMetrics implements JsonSerializable
             'ifCountWeightDelta' => $this->ifCountWeightDelta,
             'ifNestingLevelWeightDelta' => $this->ifNestingLevelWeightDelta,
             'elseCountWeightDelta' => $this->elseCountWeightDelta,
+            'coverage' => $this->coverage,
         ];
     }
 

--- a/src/Command/Presentation/TableHeaderBuilder.php
+++ b/src/Command/Presentation/TableHeaderBuilder.php
@@ -19,9 +19,10 @@ class TableHeaderBuilder
     /**
      * Get headers for grouped tables (without class column)
      *
+     * @param bool $hasCoverage Whether coverage data is available
      * @return array<int, string>
      */
-    public function getGroupedTableHeaders(): array
+    public function getGroupedTableHeaders(bool $hasCoverage = false): array
     {
         $fields = [
             "Method Name",
@@ -45,15 +46,20 @@ class TableHeaderBuilder
         $fields = $this->addHalsteadHeaders($fields);
         $fields = $this->addCyclomaticHeaders($fields);
 
+        if ($hasCoverage) {
+            $fields[] = "Line\nCoverage";
+        }
+
         return $fields;
     }
 
     /**
      * Get headers for single table (with class column)
      *
+     * @param bool $hasCoverage Whether coverage data is available
      * @return array<int, string>
      */
-    public function getSingleTableHeaders(): array
+    public function getSingleTableHeaders(bool $hasCoverage = false): array
     {
         $fields = [
             "Class",
@@ -77,6 +83,10 @@ class TableHeaderBuilder
 
         $fields = $this->addHalsteadHeaders($fields);
         $fields = $this->addCyclomaticHeaders($fields);
+
+        if ($hasCoverage) {
+            $fields[] = "Coverage";
+        }
 
         return $fields;
     }

--- a/src/Command/Presentation/TableRowBuilder.php
+++ b/src/Command/Presentation/TableRowBuilder.php
@@ -24,9 +24,10 @@ class TableRowBuilder
     /**
      * Build a table row from metrics without class information
      *
+     * @param bool $includeCoverage Whether to include coverage column
      * @return array<string, mixed>
      */
-    public function buildRow(CognitiveMetrics $metrics): array
+    public function buildRow(CognitiveMetrics $metrics, bool $includeCoverage = false): array
     {
         $row = $this->metricsToArray($metrics);
         $keys = $this->getKeys();
@@ -36,15 +37,20 @@ class TableRowBuilder
             $row = $this->addDelta($key, $metrics, $row);
         }
 
+        if ($includeCoverage) {
+            $row = $this->addCoverageValue($metrics, $row);
+        }
+
         return $row;
     }
 
     /**
      * Build a table row from metrics with class information
      *
+     * @param bool $includeCoverage Whether to include coverage column
      * @return array<string, mixed>
      */
-    public function buildRowWithClassInfo(CognitiveMetrics $metrics): array
+    public function buildRowWithClassInfo(CognitiveMetrics $metrics, bool $includeCoverage = false): array
     {
         $row = $this->metricsToArrayWithClassInfo($metrics);
         $keys = $this->getKeys();
@@ -52,6 +58,10 @@ class TableRowBuilder
         foreach ($keys as $key) {
             $row = $this->addWeightedValue($key, $metrics, $row);
             $row = $this->addDelta($key, $metrics, $row);
+        }
+
+        if ($includeCoverage) {
+            $row = $this->addCoverageValue($metrics, $row);
         }
 
         return $row;
@@ -229,5 +239,23 @@ class TableRowBuilder
         if (!method_exists($metrics, $getDeltaMethod)) {
             throw new CognitiveAnalysisException('Method not found: ' . $getDeltaMethod);
         }
+    }
+
+    /**
+     * Add coverage value to the row
+     *
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function addCoverageValue(CognitiveMetrics $metrics, array $row): array
+    {
+        $coverage = $metrics->getCoverage();
+        if ($coverage !== null) {
+            $row['coverage'] = sprintf('%.2f%%', $coverage * 100);
+        } else {
+            $row['coverage'] = 'N/A';
+        }
+
+        return $row;
     }
 }

--- a/tests/Fixtures/Coverage/coverage.xml
+++ b/tests/Fixtures/Coverage/coverage.xml
@@ -1,4 +1,4 @@
-Moand update <?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
 <coverage line-rate="0.87949067758072" branch-rate="0" lines-covered="1934" lines-valid="2199" branches-covered="0" branches-valid="0" complexity="746" version="0.4" timestamp="1759302494">
   <sources>

--- a/tests/Fixtures/Coverage/testcode-clover.xml
+++ b/tests/Fixtures/Coverage/testcode-clover.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage generated="1759745033">
+  <project timestamp="1759745033">
+    <package name="Doctrine\ORM\Tools\Pagination">
+      <file name="/home/florian/projects/cognitive-code-analysis/tests/TestCode/Paginator.php">
+        <class name="Doctrine\ORM\Tools\Pagination\Paginator" namespace="Doctrine\ORM\Tools\Pagination">
+          <metrics complexity="15" methods="13" coveredmethods="10" conditionals="0" coveredconditionals="0" statements="150" coveredstatements="120" elements="163" coveredelements="130"/>
+        </class>
+        <line num="43" type="method" name="__construct" visibility="public" complexity="2" crap="2" count="25"/>
+        <line num="47" type="stmt" count="25"/>
+        <line num="48" type="stmt" count="10"/>
+        <line num="51" type="stmt" count="25"/>
+        <line num="57" type="method" name="getQuery" visibility="public" complexity="1" crap="1" count="50"/>
+        <line num="59" type="stmt" count="50"/>
+        <line num="66" type="method" name="getFetchJoinCollection" visibility="public" complexity="1" crap="1" count="15"/>
+        <line num="68" type="stmt" count="15"/>
+        <line num="75" type="method" name="getUseOutputWalkers" visibility="public" complexity="1" crap="1" count="5"/>
+        <line num="77" type="stmt" count="5"/>
+        <line num="85" type="method" name="setUseOutputWalkers" visibility="public" complexity="1" crap="1" count="8"/>
+        <line num="87" type="stmt" count="8"/>
+        <line num="88" type="stmt" count="8"/>
+        <line num="90" type="stmt" count="8"/>
+        <line num="98" type="method" name="count" visibility="public" complexity="2" crap="2" count="0"/>
+        <line num="100" type="stmt" count="0"/>
+        <line num="101" type="stmt" count="0"/>
+        <line num="102" type="stmt" count="0"/>
+        <line num="103" type="stmt" count="0"/>
+        <line num="115" type="method" name="getIterator" visibility="public" complexity="6" crap="6.13" count="20"/>
+        <line num="117" type="stmt" count="20"/>
+        <line num="118" type="stmt" count="20"/>
+        <line num="120" type="stmt" count="20"/>
+        <line num="121" type="stmt" count="15"/>
+        <line num="122" type="stmt" count="15"/>
+        <line num="123" type="stmt" count="5"/>
+        <line num="124" type="stmt" count="5"/>
+        <line num="126" type="stmt" count="20"/>
+        <line num="127" type="stmt" count="15"/>
+        <line num="128" type="stmt" count="0"/>
+        <line num="130" type="stmt" count="15"/>
+        <line num="167" type="method" name="cloneQuery" visibility="private" complexity="1" crap="1" count="35"/>
+        <line num="169" type="stmt" count="35"/>
+        <line num="170" type="stmt" count="35"/>
+        <line num="178" type="method" name="useOutputWalker" visibility="private" complexity="2" crap="2.15" count="22"/>
+        <line num="180" type="stmt" count="22"/>
+        <line num="181" type="stmt" count="15"/>
+        <line num="182" type="stmt" count="0"/>
+        <line num="185" type="stmt" count="22"/>
+        <line num="193" type="method" name="appendTreeWalker" visibility="private" complexity="2" crap="2" count="18"/>
+        <line num="195" type="stmt" count="18"/>
+        <line num="196" type="stmt" count="10"/>
+        <line num="197" type="stmt" count="10"/>
+        <line num="200" type="stmt" count="18"/>
+        <line num="212" type="method" name="getCountQuery" visibility="private" complexity="3" crap="3.03" count="0"/>
+        <line num="214" type="stmt" count="0"/>
+        <line num="215" type="stmt" count="0"/>
+        <line num="216" type="stmt" count="0"/>
+        <line num="248" type="method" name="unbindUnusedQueryParams" visibility="private" complexity="2" crap="2" count="12"/>
+        <line num="250" type="stmt" count="12"/>
+        <line num="251" type="stmt" count="12"/>
+        <line num="252" type="stmt" count="8"/>
+        <line num="253" type="stmt" count="8"/>
+        <line num="263" type="method" name="convertWhereInIdentifiersToDatabaseValues" visibility="private" complexity="1" crap="1" count="25"/>
+        <line num="265" type="stmt" count="25"/>
+        <line num="266" type="stmt" count="25"/>
+      </file>
+    </package>
+  </project>
+</coverage>

--- a/tests/Fixtures/Coverage/testcode-cobertura.xml
+++ b/tests/Fixtures/Coverage/testcode-cobertura.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="0.8" branch-rate="0" lines-covered="120" lines-valid="150" branches-covered="0" branches-valid="0" complexity="15" version="0.4" timestamp="1759302494">
+  <sources>
+    <source>/home/florian/projects/cognitive-code-analysis/tests/TestCode</source>
+  </sources>
+  <packages>
+    <package name="Paginator.php" line-rate="0.8" branch-rate="0" complexity="15">
+      <classes>
+        <class name="Doctrine\ORM\Tools\Pagination\Paginator" filename="Paginator.php" line-rate="0.8" branch-rate="0" complexity="15">
+          <methods>
+            <method name="__construct" signature="" line-rate="1" branch-rate="0" complexity="2">
+              <lines>
+                <line number="47" hits="25"/>
+                <line number="48" hits="10"/>
+                <line number="51" hits="25"/>
+              </lines>
+            </method>
+            <method name="getQuery" signature="" line-rate="1" branch-rate="0" complexity="1">
+              <lines>
+                <line number="59" hits="50"/>
+              </lines>
+            </method>
+            <method name="getFetchJoinCollection" signature="" line-rate="1" branch-rate="0" complexity="1">
+              <lines>
+                <line number="68" hits="15"/>
+              </lines>
+            </method>
+            <method name="getUseOutputWalkers" signature="" line-rate="1" branch-rate="0" complexity="1">
+              <lines>
+                <line number="77" hits="5"/>
+              </lines>
+            </method>
+            <method name="setUseOutputWalkers" signature="" line-rate="1" branch-rate="0" complexity="1">
+              <lines>
+                <line number="87" hits="8"/>
+                <line number="88" hits="8"/>
+                <line number="90" hits="8"/>
+              </lines>
+            </method>
+            <method name="count" signature="" line-rate="0" branch-rate="0" complexity="2">
+              <lines>
+                <line number="100" hits="0"/>
+                <line number="101" hits="0"/>
+                <line number="102" hits="0"/>
+                <line number="103" hits="0"/>
+              </lines>
+            </method>
+            <method name="getIterator" signature="" line-rate="0.75" branch-rate="0" complexity="6">
+              <lines>
+                <line number="117" hits="20"/>
+                <line number="118" hits="20"/>
+                <line number="120" hits="20"/>
+                <line number="121" hits="15"/>
+                <line number="122" hits="15"/>
+                <line number="123" hits="5"/>
+                <line number="124" hits="5"/>
+                <line number="126" hits="20"/>
+                <line number="127" hits="15"/>
+                <line number="128" hits="0"/>
+                <line number="130" hits="15"/>
+              </lines>
+            </method>
+            <method name="cloneQuery" signature="" line-rate="1" branch-rate="0" complexity="1">
+              <lines>
+                <line number="169" hits="35"/>
+                <line number="170" hits="35"/>
+              </lines>
+            </method>
+            <method name="useOutputWalker" signature="" line-rate="0.75" branch-rate="0" complexity="2">
+              <lines>
+                <line number="180" hits="22"/>
+                <line number="181" hits="15"/>
+                <line number="182" hits="0"/>
+                <line number="185" hits="22"/>
+              </lines>
+            </method>
+            <method name="appendTreeWalker" signature="" line-rate="1" branch-rate="0" complexity="2">
+              <lines>
+                <line number="195" hits="18"/>
+                <line number="196" hits="10"/>
+                <line number="197" hits="10"/>
+                <line number="200" hits="18"/>
+              </lines>
+            </method>
+            <method name="getCountQuery" signature="" line-rate="0" branch-rate="0" complexity="3">
+              <lines>
+                <line number="214" hits="0"/>
+                <line number="215" hits="0"/>
+                <line number="216" hits="0"/>
+              </lines>
+            </method>
+            <method name="unbindUnusedQueryParams" signature="" line-rate="1" branch-rate="0" complexity="2">
+              <lines>
+                <line number="250" hits="12"/>
+                <line number="251" hits="12"/>
+                <line number="252" hits="8"/>
+                <line number="253" hits="8"/>
+              </lines>
+            </method>
+            <method name="convertWhereInIdentifiersToDatabaseValues" signature="" line-rate="1" branch-rate="0" complexity="1">
+              <lines>
+                <line number="265" hits="25"/>
+                <line number="266" hits="25"/>
+              </lines>
+            </method>
+          </methods>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/tests/Unit/Business/Cognitive/CognitiveMetricsTest.php
+++ b/tests/Unit/Business/Cognitive/CognitiveMetricsTest.php
@@ -122,6 +122,7 @@ class CognitiveMetricsTest extends TestCase
             'ifCountWeightDelta' => null,
             'ifNestingLevelWeightDelta' => null,
             'elseCountWeightDelta' => null,
+            'coverage' => null,
         ];
 
         $this->assertSame($expectedArray, $metrics->toArray());
@@ -161,6 +162,7 @@ class CognitiveMetricsTest extends TestCase
             'ifCountWeightDelta' => null,
             'ifNestingLevelWeightDelta' => null,
             'elseCountWeightDelta' => null,
+            'coverage' => null,
         ];
 
         $this->assertSame($expectedArray, $metrics->jsonSerialize());

--- a/tests/Unit/Command/CognitiveMetricsCommandCoverageTest.php
+++ b/tests/Unit/Command/CognitiveMetricsCommandCoverageTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\CognitiveCodeAnalysis\Tests\Unit\Command;
+
+use Phauthentic\CognitiveCodeAnalysis\Application;
+use Phauthentic\CognitiveCodeAnalysis\Command\CognitiveMetricsCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Tests for coverage functionality in CognitiveMetricsCommand
+ */
+class CognitiveMetricsCommandCoverageTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('coverageFormatProvider')]
+    public function testAnalyseWithCoverageFormats(string $option, string $file, string $format): void
+    {
+        $application = new Application();
+        $command = $application->getContainer()->get(CognitiveMetricsCommand::class);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'path' => __DIR__ . '/../../TestCode/Paginator.php',
+            $option => __DIR__ . '/../../Fixtures/Coverage/' . $file,
+        ]);
+
+        $this->assertEquals(
+            Command::SUCCESS,
+            $tester->getStatusCode(),
+            "Command should succeed with {$format} coverage"
+        );
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Coverage', $output, 'Output should contain Coverage column');
+        $this->assertStringContainsString('%', $output, 'Output should contain percentage values');
+    }
+
+    #[Test]
+    public function testAnalyseWithBothCoverageFormatsReturnsError(): void
+    {
+        $application = new Application();
+        $command = $application->getContainer()->get(CognitiveMetricsCommand::class);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'path' => __DIR__ . '/../../TestCode/Paginator.php',
+            '--coverage-clover' => __DIR__ . '/../../Fixtures/Coverage/testcode-clover.xml',
+            '--coverage-cobertura' => __DIR__ . '/../../Fixtures/Coverage/testcode-cobertura.xml',
+        ]);
+
+        $this->assertEquals(
+            Command::FAILURE,
+            $tester->getStatusCode(),
+            'Command should fail when both coverage formats are specified'
+        );
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Only one coverage format can be specified at a time', $output);
+    }
+
+    #[Test]
+    public function testAnalyseWithNonExistentCoverageFile(): void
+    {
+        $application = new Application();
+        $command = $application->getContainer()->get(CognitiveMetricsCommand::class);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'path' => __DIR__ . '/../../TestCode/Paginator.php',
+            '--coverage-clover' => __DIR__ . '/../../Fixtures/Coverage/does-not-exist.xml',
+        ]);
+
+        $this->assertEquals(
+            Command::FAILURE,
+            $tester->getStatusCode(),
+            'Command should fail with non-existent coverage file'
+        );
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Coverage file not found', $output);
+    }
+
+    #[Test]
+    public function testAnalyseWithoutCoverageDoesNotShowCoverageColumn(): void
+    {
+        $application = new Application();
+        $command = $application->getContainer()->get(CognitiveMetricsCommand::class);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'path' => __DIR__ . '/../../TestCode/Paginator.php',
+        ]);
+
+        $this->assertEquals(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+        // Check that the Coverage column header is not in the output
+        $this->assertStringNotContainsString(
+            'Line\nCoverage',
+            $output,
+            'Output should not contain Coverage column when no coverage file is provided'
+        );
+    }
+
+    #[Test]
+    #[DataProvider('methodLevelCoverageProvider')]
+    public function testAnalyseShowsMethodLevelCoverage(string $format, string $file, string $zeroMethod, string $fullMethod): void
+    {
+        $application = new Application();
+        $command = $application->getContainer()->get(CognitiveMetricsCommand::class);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'path' => __DIR__ . '/../../TestCode/Paginator.php',
+            "--coverage-{$format}" => __DIR__ . '/../../Fixtures/Coverage/' . $file,
+        ]);
+
+        $this->assertEquals(Command::SUCCESS, $tester->getStatusCode());
+        $output = $tester->getDisplay();
+
+        // The Paginator class has methods with different coverage levels
+        $this->assertMatchesRegularExpression(
+            "/{$zeroMethod}.*0\.00%/s",
+            $output,
+            "Should show 0.00% coverage for {$zeroMethod} method"
+        );
+
+        $this->assertMatchesRegularExpression(
+            "/{$fullMethod}.*100\.00%/s",
+            $output,
+            "Should show 100.00% coverage for {$fullMethod} method"
+        );
+    }
+
+    #[Test]
+    public function testAnalyseWithCoverageAndMultiplePaths(): void
+    {
+        $application = new Application();
+        $command = $application->getContainer()->get(CognitiveMetricsCommand::class);
+        $tester = new CommandTester($command);
+
+        $tester->execute([
+            'path' => __DIR__ . '/../../TestCode/Paginator.php,' . __DIR__ . '/../../TestCode/FileWithTwoClasses.php',
+            '--coverage-clover' => __DIR__ . '/../../Fixtures/Coverage/testcode-clover.xml',
+        ]);
+
+        $this->assertEquals(
+            Command::SUCCESS,
+            $tester->getStatusCode(),
+            'Command should succeed with coverage and multiple paths'
+        );
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Coverage', $output, 'Output should contain Coverage column');
+        $this->assertStringContainsString('Paginator', $output, 'Output should contain Paginator class');
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function coverageFormatProvider(): array
+    {
+        return [
+            'Clover format' => [
+                '--coverage-clover',
+                'testcode-clover.xml',
+                'Clover',
+            ],
+            'Cobertura format' => [
+                '--coverage-cobertura',
+                'testcode-cobertura.xml',
+                'Cobertura',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string, string, string}>
+     */
+    public static function methodLevelCoverageProvider(): array
+    {
+        return [
+            'Clover format shows method coverage' => [
+                'clover',
+                'testcode-clover.xml',
+                'count',
+                'getQuery',
+            ],
+            'Cobertura format shows method coverage' => [
+                'cobertura',
+                'testcode-cobertura.xml',
+                'count',
+                'getQuery',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This will display the code coverage per method and class if a coverage file is provided. This enables you to make a better judgment regarding refactoring and testing.
