### PR TITLE
HTML and Markdown report generation with single table configuration

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli
+FROM php:8.5-cli
 
 RUN apt-get update \
     && apt-get install -y libzip-dev zip git wget gpg \

--- a/src/Business/Cognitive/Report/CognitiveReportFactory.php
+++ b/src/Business/Cognitive/Report/CognitiveReportFactory.php
@@ -37,7 +37,7 @@ class CognitiveReportFactory implements CognitiveReportFactoryInterface
         $builtIn = match ($type) {
             'json' => new JsonReport(),
             'csv' => new CsvReport(),
-            'html' => new HtmlReport(),
+            'html' => new HtmlReport($config),
             'markdown' => new MarkdownReport($config),
             'checkstyle' => new CheckstyleReport($config),
             'junit' => new JUnitReport($config),

--- a/src/Business/Cognitive/Report/HtmlReport.php
+++ b/src/Business/Cognitive/Report/HtmlReport.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Phauthentic\CognitiveCodeAnalysis\Business\Cognitive\Report;
 
+use Phauthentic\CognitiveCodeAnalysis\Business\Cognitive\CognitiveMetrics;
 use Phauthentic\CognitiveCodeAnalysis\Business\Cognitive\CognitiveMetricsCollection;
 use Phauthentic\CognitiveCodeAnalysis\Business\Cognitive\Delta;
 use Phauthentic\CognitiveCodeAnalysis\Business\Utility\Datetime;
 use Phauthentic\CognitiveCodeAnalysis\CognitiveAnalysisException;
+use Phauthentic\CognitiveCodeAnalysis\Config\CognitiveConfig;
 
 /**
  * HtmlReport class for exporting metrics as an HTML file.
@@ -27,15 +29,16 @@ class HtmlReport implements ReportGeneratorInterface
         'Return Count',
         'Variable Count',
         'Property Call Count',
-        'Combined Cognitive Complexity'
+        'Combined Cognitive Complexity',
     ];
+
+    public function __construct(
+        private readonly CognitiveConfig $config,
+    ) {
+    }
 
     /**
      * Export metrics to an HTML file using Bootstrap 5.
-     *
-     * @param CognitiveMetricsCollection $metrics
-     * @param string $filename
-     * @return void
      */
     public function export(CognitiveMetricsCollection $metrics, string $filename): void
     {
@@ -69,17 +72,68 @@ class HtmlReport implements ReportGeneratorInterface
         return $metricRow . '</td>';
     }
 
-    /**
-     * Generate HTML content using the metrics data.
-     *
-     * @param CognitiveMetricsCollection $metrics
-     * @return string
-     */
     private function generateHtml(CognitiveMetricsCollection $metrics): string
+    {
+        return $this->config->groupByClass
+            ? $this->generateGroupedHtml($metrics)
+            : $this->generateSingleTableHtml($metrics);
+    }
+
+    private function generateGroupedHtml(CognitiveMetricsCollection $metrics): string
     {
         $groupedByClass = $metrics->groupBy('class');
 
         ob_start();
+        $this->renderDocumentStart(count($groupedByClass));
+        foreach ($groupedByClass as $class => $methods) {
+            ?>
+            <table class="table table-bordered">
+                <thead>
+                    <tr>
+                        <th colspan="<?php echo count($this->header); ?>" class="table-primary"><?php echo $this->escape((string)$class); ?></th>
+                    </tr>
+                    <?php echo $this->renderHeaderRow(false); ?>
+                </thead>
+                <tbody>
+                <?php foreach ($methods as $data) : ?>
+                    <?php echo $this->renderMethodRow($data, false); ?>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+            <?php
+        }
+        $this->renderDocumentEnd();
+
+        return $this->captureOutput();
+    }
+
+    private function generateSingleTableHtml(CognitiveMetricsCollection $metrics): string
+    {
+        $groupedByClass = $metrics->groupBy('class');
+        $totalMethods = count($metrics);
+
+        ob_start();
+        $this->renderDocumentStart(count($groupedByClass));
+        ?>
+        <h2 class="h5 mb-3">All Methods (<?php echo $totalMethods; ?> total)</h2>
+        <table class="table table-bordered">
+            <thead>
+                <?php echo $this->renderHeaderRow(true); ?>
+            </thead>
+            <tbody>
+            <?php foreach ($metrics as $data) : ?>
+                <?php echo $this->renderMethodRow($data, true); ?>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+        <?php
+        $this->renderDocumentEnd();
+
+        return $this->captureOutput();
+    }
+
+    private function renderDocumentStart(int $classCount): void
+    {
         ?>
         <!DOCTYPE html>
         <html lang="en">
@@ -93,44 +147,73 @@ class HtmlReport implements ReportGeneratorInterface
         <div class="container-fluid">
             <h1 class="mb-4">Cognitive Metrics Report - <?php echo (new Datetime())->format('Y-m-d H:i:s') ?></h1>
             <p>
-                This report contains the cognitive complexity metrics for the analyzed code in <?php echo count($groupedByClass); ?> classes.
+                This report contains the cognitive complexity metrics for the analyzed code in <?php echo $classCount; ?> classes.
             </p>
+        <?php
+    }
 
-            <?php foreach ($groupedByClass as $class => $methods) : ?>
-                <table class="table table-bordered">
-                    <thead>
-                        <tr>
-                            <th colspan="10" class="table-primary"><?php echo $this->escape((string)$class); ?></th>
-                        </tr>
-                        <tr>
-                            <?php foreach ($this->header as $column) : ?>
-                                <th class="table-secondary"><?php echo $this->escape($column); ?></th>
-                            <?php endforeach; ?>
-                        </tr>
-                    </thead>
-                    <tbody>
-                    <?php foreach ($methods as $data) : ?>
-                        <tr>
-                            <td><?php echo $this->escape($data->getMethod()); ?></td>
-                            <?php echo $this->generateMetricRow($data->getLineCount(), $data->getLineCountWeight(), $data->getLineCountWeightDelta()); ?>
-                            <?php echo $this->generateMetricRow($data->getArgCount(), $data->getArgCountWeight(), $data->getArgCountWeightDelta()); ?>
-                            <?php echo $this->generateMetricRow($data->getIfCount(), $data->getIfCountWeight(), $data->getIfCountWeightDelta()); ?>
-                            <?php echo $this->generateMetricRow($data->getIfNestingLevel(), $data->getIfNestingLevelWeight(), $data->getIfNestingLevelWeightDelta()); ?>
-                            <?php echo $this->generateMetricRow($data->getElseCount(), $data->getElseCountWeight(), $data->getElseCountWeightDelta()); ?>
-                            <?php echo $this->generateMetricRow($data->getReturnCount(), $data->getReturnCountWeight(), $data->getReturnCountWeightDelta()); ?>
-                            <?php echo $this->generateMetricRow($data->getVariableCount(), $data->getVariableCountWeight(), $data->getVariableCountWeightDelta()); ?>
-                            <?php echo $this->generateMetricRow($data->getPropertyCallCount(), $data->getPropertyCallCountWeight(), $data->getPropertyCallCountWeightDelta()); ?>
-                            <td><?php echo $this->formatNumber($data->getScore()); ?></td>
-                        </tr>
-                    <?php endforeach; ?>
-                    </tbody>
-                </table>
-            <?php endforeach; ?>
-
+    private function renderDocumentEnd(): void
+    {
+        ?>
         </div>
         </body>
         </html>
         <?php
+    }
+
+    private function renderHeaderRow(bool $includeClass): string
+    {
+        ob_start();
+        ?>
+        <tr>
+            <?php if ($includeClass) : ?>
+                <th class="table-secondary">Class</th>
+            <?php endif; ?>
+            <?php foreach ($this->header as $column) : ?>
+                <th class="table-secondary"><?php echo $this->escape($column); ?></th>
+            <?php endforeach; ?>
+        </tr>
+        <?php
+        $result = ob_get_clean();
+
+        if ($result === false) {
+            throw new CognitiveAnalysisException('Could not generate HTML header row');
+        }
+
+        return $result;
+    }
+
+    private function renderMethodRow(CognitiveMetrics $data, bool $includeClass): string
+    {
+        ob_start();
+        ?>
+        <tr>
+            <?php if ($includeClass) : ?>
+                <td><?php echo $this->escape($data->getClass()); ?></td>
+            <?php endif; ?>
+            <td><?php echo $this->escape($data->getMethod()); ?></td>
+            <?php echo $this->generateMetricRow($data->getLineCount(), $data->getLineCountWeight(), $data->getLineCountWeightDelta()); ?>
+            <?php echo $this->generateMetricRow($data->getArgCount(), $data->getArgCountWeight(), $data->getArgCountWeightDelta()); ?>
+            <?php echo $this->generateMetricRow($data->getIfCount(), $data->getIfCountWeight(), $data->getIfCountWeightDelta()); ?>
+            <?php echo $this->generateMetricRow($data->getIfNestingLevel(), $data->getIfNestingLevelWeight(), $data->getIfNestingLevelWeightDelta()); ?>
+            <?php echo $this->generateMetricRow($data->getElseCount(), $data->getElseCountWeight(), $data->getElseCountWeightDelta()); ?>
+            <?php echo $this->generateMetricRow($data->getReturnCount(), $data->getReturnCountWeight(), $data->getReturnCountWeightDelta()); ?>
+            <?php echo $this->generateMetricRow($data->getVariableCount(), $data->getVariableCountWeight(), $data->getVariableCountWeightDelta()); ?>
+            <?php echo $this->generateMetricRow($data->getPropertyCallCount(), $data->getPropertyCallCountWeight(), $data->getPropertyCallCountWeightDelta()); ?>
+            <td><?php echo $this->formatNumber($data->getScore()); ?></td>
+        </tr>
+        <?php
+        $result = ob_get_clean();
+
+        if ($result === false) {
+            throw new CognitiveAnalysisException('Could not generate HTML method row');
+        }
+
+        return $result;
+    }
+
+    private function captureOutput(): string
+    {
         $result = ob_get_clean();
 
         if ($result === false) {

--- a/src/Business/Cognitive/Report/MarkdownReport.php
+++ b/src/Business/Cognitive/Report/MarkdownReport.php
@@ -20,7 +20,7 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
     use MarkdownFormatterTrait;
 
     private CognitiveConfig $config;
-    /** @var resource|false|null */
+    /** @var resource|null */
     private $fileHandle = null;
     private bool $isStreaming = false;
     /** @var array<int|string> */
@@ -428,11 +428,12 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
      */
     public function startReport(string $filename): void
     {
-        $this->fileHandle = fopen($filename, 'wb');
-        if ($this->fileHandle === false) {
+        $fileHandle = fopen($filename, 'wb');
+        if ($fileHandle === false) {
             throw new CognitiveAnalysisException(sprintf('Could not open file %s for writing', $filename));
         }
 
+        $this->fileHandle = $fileHandle;
         $this->isStreaming = true;
         $this->processedClasses = [];
 
@@ -453,7 +454,7 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
             $header .= $this->buildTableSeparatorWithClass() . "\n";
         }
 
-        fwrite($this->fileHandle, $header);
+        fwrite($fileHandle, $header);
     }
 
     /**
@@ -461,15 +462,13 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
      */
     public function writeMetricBatch(CognitiveMetricsCollection $batch): void
     {
-        if (!$this->isStreaming || $this->fileHandle === null) {
+        $fileHandle = $this->fileHandle;
+        if (!$this->isStreaming || $fileHandle === null) {
             throw new CognitiveAnalysisException('Streaming not started. Call startReport() first.');
         }
 
-        // Type guard: fileHandle is guaranteed to be resource at this point
-        assert($this->fileHandle !== false);
-
         if (!$this->config->groupByClass) {
-            $this->writeSingleTableBatch($batch);
+            $this->writeSingleTableBatch($batch, $fileHandle);
             return;
         }
 
@@ -513,14 +512,15 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
 
             $classSection .= "\n---\n\n";
 
-            fwrite($this->fileHandle, $classSection);
+            fwrite($fileHandle, $classSection);
         }
     }
 
-    private function writeSingleTableBatch(CognitiveMetricsCollection $batch): void
+    /**
+     * @param resource $fileHandle
+     */
+    private function writeSingleTableBatch(CognitiveMetricsCollection $batch, $fileHandle): void
     {
-        assert($this->fileHandle !== false);
-
         $filteredMetrics = $this->filterMetrics($batch);
         $rows = '';
 
@@ -532,7 +532,7 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
             return;
         }
 
-        fwrite($this->fileHandle, $rows);
+        fwrite($fileHandle, $rows);
     }
 
     /**
@@ -540,14 +540,12 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
      */
     public function finalizeReport(): void
     {
-        if (!$this->isStreaming || $this->fileHandle === null) {
+        $fileHandle = $this->fileHandle;
+        if (!$this->isStreaming || $fileHandle === null) {
             throw new CognitiveAnalysisException('Streaming not started or file handle not available.');
         }
 
-        // Type guard: fileHandle is guaranteed to be resource at this point
-        assert($this->fileHandle !== false);
-
-        fclose($this->fileHandle);
+        fclose($fileHandle);
 
         $this->isStreaming = false;
         $this->fileHandle = null;

--- a/src/Business/Cognitive/Report/MarkdownReport.php
+++ b/src/Business/Cognitive/Report/MarkdownReport.php
@@ -472,6 +472,14 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
             return;
         }
 
+        $this->writeGroupedByClassBatch($batch, $fileHandle);
+    }
+
+    /**
+     * @param resource $fileHandle
+     */
+    private function writeGroupedByClassBatch(CognitiveMetricsCollection $batch, $fileHandle): void
+    {
         $groupedByClass = $batch->groupBy('class');
 
         foreach ($groupedByClass as $class => $methods) {
@@ -481,39 +489,37 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
                 continue;
             }
 
-            // Check if we've already processed this class
             if (in_array($class, $this->processedClasses, true)) {
                 continue;
             }
 
             $this->processedClasses[] = $class;
 
-            // Get file path from first method in the collection
-            $firstMethod = null;
-            foreach ($filteredMethods as $method) {
-                $firstMethod = $method;
-                break;
-            }
-
-            $classSection = "* **Class:** " . $this->escape((string)$class) . "\n";
-            if ($firstMethod !== null) {
-                $classSection .= "* **File:** " . $this->escape($firstMethod->getFileName()) . "\n";
-            }
-            $classSection .= "\n";
-
-            // Table header and separator
-            $classSection .= $this->buildTableHeader() . "\n";
-            $classSection .= $this->buildTableSeparator() . "\n";
-
-            // Table rows
-            foreach ($filteredMethods as $data) {
-                $classSection .= $this->buildTableRow($data) . "\n";
-            }
-
-            $classSection .= "\n---\n\n";
-
-            fwrite($fileHandle, $classSection);
+            fwrite($fileHandle, $this->buildClassSection((string) $class, $filteredMethods));
         }
+    }
+
+    private function buildClassSection(string $class, CognitiveMetricsCollection $filteredMethods): string
+    {
+        $firstMethod = null;
+        foreach ($filteredMethods as $method) {
+            $firstMethod = $method;
+            break;
+        }
+
+        $classSection = "* **Class:** " . $this->escape($class) . "\n";
+        if ($firstMethod !== null) {
+            $classSection .= "* **File:** " . $this->escape($firstMethod->getFileName()) . "\n";
+        }
+        $classSection .= "\n";
+        $classSection .= $this->buildTableHeader() . "\n";
+        $classSection .= $this->buildTableSeparator() . "\n";
+
+        foreach ($filteredMethods as $data) {
+            $classSection .= $this->buildTableRow($data) . "\n";
+        }
+
+        return $classSection . "\n---\n\n";
     }
 
     /**

--- a/src/Business/Cognitive/Report/MarkdownReport.php
+++ b/src/Business/Cognitive/Report/MarkdownReport.php
@@ -447,6 +447,12 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
 
         $header .= "---\n\n";
 
+        if (!$this->config->groupByClass) {
+            $header .= "## All Methods\n\n";
+            $header .= $this->buildTableHeaderWithClass() . "\n";
+            $header .= $this->buildTableSeparatorWithClass() . "\n";
+        }
+
         fwrite($this->fileHandle, $header);
     }
 
@@ -461,6 +467,11 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
 
         // Type guard: fileHandle is guaranteed to be resource at this point
         assert($this->fileHandle !== false);
+
+        if (!$this->config->groupByClass) {
+            $this->writeSingleTableBatch($batch);
+            return;
+        }
 
         $groupedByClass = $batch->groupBy('class');
 
@@ -504,6 +515,24 @@ class MarkdownReport implements ReportGeneratorInterface, StreamableReportInterf
 
             fwrite($this->fileHandle, $classSection);
         }
+    }
+
+    private function writeSingleTableBatch(CognitiveMetricsCollection $batch): void
+    {
+        assert($this->fileHandle !== false);
+
+        $filteredMetrics = $this->filterMetrics($batch);
+        $rows = '';
+
+        foreach ($filteredMetrics as $data) {
+            $rows .= $this->buildTableRowWithClass($data) . "\n";
+        }
+
+        if ($rows === '') {
+            return;
+        }
+
+        fwrite($this->fileHandle, $rows);
     }
 
     /**

--- a/tests/Unit/Business/Cognitive/Report/HtmlReporterContent.html
+++ b/tests/Unit/Business/Cognitive/Report/HtmlReporterContent.html
@@ -12,34 +12,32 @@
             <p>
                 This report contains the cognitive complexity metrics for the analyzed code in 1 classes.
             </p>
-
-                            <table class="table table-bordered">
-                    <thead>
-                        <tr>
-                            <th colspan="10" class="table-primary">TestClass</th>
-                        </tr>
-                        <tr>
-                                                            <th class="table-secondary">Method</th>
-                                                            <th class="table-secondary">Line Count</th>
-                                                            <th class="table-secondary">Argument Count</th>
-                                                            <th class="table-secondary">If Count</th>
-                                                            <th class="table-secondary">If Nesting Level</th>
-                                                            <th class="table-secondary">Else Count</th>
-                                                            <th class="table-secondary">Return Count</th>
-                                                            <th class="table-secondary">Variable Count</th>
-                                                            <th class="table-secondary">Property Call Count</th>
-                                                            <th class="table-secondary">Combined Cognitive Complexity</th>
-                                                    </tr>
-                    </thead>
-                    <tbody>
+                    <table class="table table-bordered">
+                <thead>
+                    <tr>
+                        <th colspan="10" class="table-primary">TestClass</th>
+                    </tr>
+                            <tr>
+                                        <th class="table-secondary">Method</th>
+                            <th class="table-secondary">Line Count</th>
+                            <th class="table-secondary">Argument Count</th>
+                            <th class="table-secondary">If Count</th>
+                            <th class="table-secondary">If Nesting Level</th>
+                            <th class="table-secondary">Else Count</th>
+                            <th class="table-secondary">Return Count</th>
+                            <th class="table-secondary">Variable Count</th>
+                            <th class="table-secondary">Property Call Count</th>
+                            <th class="table-secondary">Combined Cognitive Complexity</th>
+                    </tr>
+                        </thead>
+                <tbody>
                                             <tr>
-                            <td>testMethod</td>
-                            <td>10 (0.500)</td>                            <td>2 (0.300)</td>                            <td>4 (0.600)</td>                            <td>2 (0.500)</td>                            <td>1 (0.200)</td>                            <td>1 (0.200)</td>                            <td>5 (0.400)</td>                            <td>3 (0.300)</td>                            <td>0.000</td>
-                        </tr>
+                        <td>testMethod</td>
+            <td>10 (0.500)</td>            <td>2 (0.300)</td>            <td>4 (0.600)</td>            <td>2 (0.500)</td>            <td>1 (0.200)</td>            <td>1 (0.200)</td>            <td>5 (0.400)</td>            <td>3 (0.300)</td>            <td>0.000</td>
+        </tr>
                                         </tbody>
-                </table>
-            
-        </div>
+            </table>
+                    </div>
         </body>
         </html>
         

--- a/tests/Unit/Business/Cognitive/Report/HtmlReporterContent_SingleTable.html
+++ b/tests/Unit/Business/Cognitive/Report/HtmlReporterContent_SingleTable.html
@@ -1,0 +1,53 @@
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Cognitive Complexity Metrics Report</title>
+            <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+        </head>
+        <body>
+        <div class="container-fluid">
+            <h1 class="mb-4">Cognitive Metrics Report - 2023-10-01 12:00:00</h1>
+            <p>
+                This report contains the cognitive complexity metrics for the analyzed code in 2 classes.
+            </p>
+                <h2 class="h5 mb-3">All Methods (3 total)</h2>
+        <table class="table table-bordered">
+            <thead>
+                        <tr>
+                            <th class="table-secondary">Class</th>
+                                        <th class="table-secondary">Method</th>
+                            <th class="table-secondary">Line Count</th>
+                            <th class="table-secondary">Argument Count</th>
+                            <th class="table-secondary">If Count</th>
+                            <th class="table-secondary">If Nesting Level</th>
+                            <th class="table-secondary">Else Count</th>
+                            <th class="table-secondary">Return Count</th>
+                            <th class="table-secondary">Variable Count</th>
+                            <th class="table-secondary">Property Call Count</th>
+                            <th class="table-secondary">Combined Cognitive Complexity</th>
+                    </tr>
+                    </thead>
+            <tbody>
+                                    <tr>
+                            <td>TestClass</td>
+                        <td>testMethod</td>
+            <td>10 (0.500)</td>            <td>2 (0.300)</td>            <td>4 (0.600)</td>            <td>2 (0.500)</td>            <td>1 (0.200)</td>            <td>1 (0.200)</td>            <td>5 (0.400)</td>            <td>3 (0.300)</td>            <td>0.300</td>
+        </tr>
+                                            <tr>
+                            <td>TestClass</td>
+                        <td>anotherMethod</td>
+            <td>5 (0.200)</td>            <td>1 (0.100)</td>            <td>1 (0.200)</td>            <td>1 (0.100)</td>            <td>0 (0.000)</td>            <td>1 (0.100)</td>            <td>2 (0.100)</td>            <td>1 (0.100)</td>            <td>0.050</td>
+        </tr>
+                                            <tr>
+                            <td>AnotherClass</td>
+                        <td>complexMethod</td>
+            <td>20 (1.000)</td>            <td>4 (0.600)</td>            <td>8 (1.200)</td>            <td>3 (1.000)</td>            <td>4 (0.600)</td>            <td>3 (0.500)</td>            <td>10 (0.800)</td>            <td>5 (0.500)</td>            <td>0.800</td>
+        </tr>
+                                </tbody>
+        </table>
+                </div>
+        </body>
+        </html>
+        

--- a/tests/Unit/Business/Cognitive/Report/HtmlReporterTest.php
+++ b/tests/Unit/Business/Cognitive/Report/HtmlReporterTest.php
@@ -8,19 +8,21 @@ use Phauthentic\CognitiveCodeAnalysis\Business\Cognitive\CognitiveMetrics;
 use Phauthentic\CognitiveCodeAnalysis\Business\Cognitive\CognitiveMetricsCollection;
 use Phauthentic\CognitiveCodeAnalysis\Business\Cognitive\Report\HtmlReport;
 use Phauthentic\CognitiveCodeAnalysis\Business\Utility\Datetime;
+use Phauthentic\CognitiveCodeAnalysis\Config\ConfigLoader;
+use Phauthentic\CognitiveCodeAnalysis\Config\ConfigService;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Processor;
 
 class HtmlReporterTest extends TestCase
 {
-    private HtmlReport $csvExporter;
     private string $filename;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->csvExporter = new HtmlReport();
-        $this->filename = sys_get_temp_dir() . '/test_metrics.csv';
+        $this->filename = sys_get_temp_dir() . '/test_metrics.html';
         Datetime::$fixedDate = '2023-10-01 12:00:00';
     }
 
@@ -30,14 +32,79 @@ class HtmlReporterTest extends TestCase
         if (file_exists($this->filename)) {
             unlink($this->filename);
         }
-        DateTime::$fixedDate = null;
+        Datetime::$fixedDate = null;
+    }
+
+    /**
+     * @return array<string, array{string, string, bool}>
+     */
+    public static function configurationProvider(): array
+    {
+        return [
+            'Grouped by class' => ['all-metrics-config.yml', 'HtmlReporterContent.html', true],
+            'Single table' => ['single-table-config.yml', 'HtmlReporterContent_SingleTable.html', false],
+        ];
     }
 
     #[Test]
-    public function testExportCreatesFile(): void
+    #[DataProvider('configurationProvider')]
+    public function testExportWithConfiguration(string $configFile, string $expectedFile, bool $useSimpleMetrics): void
+    {
+        $config = $this->loadConfig($configFile);
+        $exporter = new HtmlReport($config);
+        $metricsCollection = $useSimpleMetrics
+            ? $this->createSimpleMetricsCollection()
+            : $this->createMultiClassMetricsCollection();
+
+        $exporter->export($metricsCollection, $this->filename);
+
+        $this->assertFileEquals(__DIR__ . '/' . $expectedFile, $this->filename);
+    }
+
+    private function loadConfig(string $configFile): \Phauthentic\CognitiveCodeAnalysis\Config\CognitiveConfig
+    {
+        $configService = new ConfigService(
+            new Processor(),
+            new ConfigLoader()
+        );
+        $configService->loadConfig(__DIR__ . '/../../../../Fixtures/' . $configFile);
+
+        return $configService->getConfig();
+    }
+
+    private function createSimpleMetricsCollection(): CognitiveMetricsCollection
     {
         $metricsCollection = new CognitiveMetricsCollection();
-        $metrics = new CognitiveMetrics([
+        $metricsCollection->add(new CognitiveMetrics([
+            'class' => 'TestClass',
+            'method' => 'testMethod',
+            'file' => 'TestClass.php',
+            'lineCount' => 10,
+            'argCount' => 2,
+            'returnCount' => 1,
+            'variableCount' => 5,
+            'propertyCallCount' => 3,
+            'ifCount' => 4,
+            'ifNestingLevel' => 2,
+            'elseCount' => 1,
+            'lineCountWeight' => 0.5,
+            'argCountWeight' => 0.3,
+            'returnCountWeight' => 0.2,
+            'variableCountWeight' => 0.4,
+            'propertyCallCountWeight' => 0.3,
+            'ifCountWeight' => 0.6,
+            'ifNestingLevelWeight' => 0.5,
+            'elseCountWeight' => 0.2,
+        ]));
+
+        return $metricsCollection;
+    }
+
+    private function createMultiClassMetricsCollection(): CognitiveMetricsCollection
+    {
+        $metricsCollection = new CognitiveMetricsCollection();
+
+        $metrics1 = new CognitiveMetrics([
             'class' => 'TestClass',
             'method' => 'testMethod',
             'file' => 'TestClass.php',
@@ -58,14 +125,57 @@ class HtmlReporterTest extends TestCase
             'ifNestingLevelWeight' => 0.5,
             'elseCountWeight' => 0.2,
         ]);
+        $metrics1->setScore(0.3);
+        $metricsCollection->add($metrics1);
 
-        $metricsCollection->add($metrics);
+        $metrics2 = new CognitiveMetrics([
+            'class' => 'TestClass',
+            'method' => 'anotherMethod',
+            'file' => 'TestClass.php',
+            'lineCount' => 5,
+            'argCount' => 1,
+            'returnCount' => 1,
+            'variableCount' => 2,
+            'propertyCallCount' => 1,
+            'ifCount' => 1,
+            'ifNestingLevel' => 1,
+            'elseCount' => 0,
+            'lineCountWeight' => 0.2,
+            'argCountWeight' => 0.1,
+            'returnCountWeight' => 0.1,
+            'variableCountWeight' => 0.1,
+            'propertyCallCountWeight' => 0.1,
+            'ifCountWeight' => 0.2,
+            'ifNestingLevelWeight' => 0.1,
+            'elseCountWeight' => 0.0,
+        ]);
+        $metrics2->setScore(0.05);
+        $metricsCollection->add($metrics2);
 
-        $this->csvExporter->export($metricsCollection, $this->filename);
+        $metrics3 = new CognitiveMetrics([
+            'class' => 'AnotherClass',
+            'method' => 'complexMethod',
+            'file' => 'AnotherClass.php',
+            'lineCount' => 20,
+            'argCount' => 4,
+            'returnCount' => 3,
+            'variableCount' => 10,
+            'propertyCallCount' => 5,
+            'ifCount' => 8,
+            'ifNestingLevel' => 3,
+            'elseCount' => 4,
+            'lineCountWeight' => 1.0,
+            'argCountWeight' => 0.6,
+            'returnCountWeight' => 0.5,
+            'variableCountWeight' => 0.8,
+            'propertyCallCountWeight' => 0.5,
+            'ifCountWeight' => 1.2,
+            'ifNestingLevelWeight' => 1.0,
+            'elseCountWeight' => 0.6,
+        ]);
+        $metrics3->setScore(0.8);
+        $metricsCollection->add($metrics3);
 
-        $this->assertFileEquals(
-            __DIR__ . '/HtmlReporterContent.html',
-            $this->filename
-        );
+        return $metricsCollection;
     }
 }

--- a/tests/Unit/Business/Cognitive/Report/MarkdownReporterContent_SingleTableStreaming.md
+++ b/tests/Unit/Business/Cognitive/Report/MarkdownReporterContent_SingleTableStreaming.md
@@ -1,0 +1,13 @@
+# Cognitive Metrics Report
+
+**Generated:** 2023-10-01 12:00:00
+
+---
+
+## All Methods
+
+| Class | Method | Lines | Args | Returns | Variables | Property Calls | If | If Nesting | Else | Cognitive Complexity | Halstead Volume | Halstead Difficulty | Halstead Effort | Cyclomatic Complexity |
+|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|
+| TestClass | testMethod | 10 (0.500) | 2 (0.300) | 1 (0.200) | 5 (0.400) | 3 (0.300) | 4 (0.600) | 2 (0.500) | 1 (0.200) | 0.300 | 573.211 | 12.500 | 7,165.138 | 5 (low) |
+| TestClass | anotherMethod | 5 (0.200) | 1 (0.100) | 1 (0.100) | 2 (0.100) | 1 (0.100) | 1 (0.200) | 1 (0.100) | 0 (0.000) | 0.050 | 185.470 | 6.250 | 1,159.188 | 2 (low) |
+| AnotherClass | complexMethod | 20 (1.000) | 4 (0.600) | 3 (0.500) | 10 (0.800) | 5 (0.500) | 8 (1.200) | 3 (1.000) | 4 (0.600) | 0.800 | 1,357.824 | 25.000 | 33,945.600 | 12 (medium) |

--- a/tests/Unit/Business/Cognitive/Report/MarkdownReporterTest.php
+++ b/tests/Unit/Business/Cognitive/Report/MarkdownReporterTest.php
@@ -72,6 +72,28 @@ class MarkdownReporterTest extends TestCase
         );
     }
 
+    #[Test]
+    public function testStreamingExportWithSingleTableConfiguration(): void
+    {
+        $configService = new ConfigService(
+            new Processor(),
+            new ConfigLoader()
+        );
+        $configService->loadConfig(__DIR__ . '/../../../../Fixtures/single-table-config.yml');
+        $config = $configService->getConfig();
+
+        $metricsCollection = $this->createTestMetricsCollection();
+        $exporter = new MarkdownReport($config);
+        $exporter->startReport($this->filename);
+        $exporter->writeMetricBatch($metricsCollection);
+        $exporter->finalizeReport();
+
+        $this->assertFileEquals(
+            __DIR__ . '/MarkdownReporterContent_SingleTableStreaming.md',
+            $this->filename
+        );
+    }
+
     private function createTestMetricsCollection(): CognitiveMetricsCollection
     {
         $metricsCollection = new CognitiveMetricsCollection();


### PR DESCRIPTION
- Updated HtmlReport to support a single table layout for metrics when configured.
- Modified MarkdownReport to include a single table format for all methods.
- Added new test cases to validate the single table output for both HTML and Markdown reports.
- Introduced configuration options to toggle between grouped and single table formats in reports.

Refs https://github.com/Phauthentic/cognitive-code-analysis/issues/58